### PR TITLE
Alter redis queue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,29 +1,31 @@
 version: '3.8'
 
 services:
-  twilight-back:
-    build:
-      context: .
-    container_name: twilight-back
-    ports:
-      - "80:8080"
-    restart: always
-    depends_on:
-      redis:
-        condition: service_healthy
-      mysql:
-        condition: service_healthy
-    environment:
-      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL}
-      SPRING_DATASOURCE_USERNAME: ${MYSQL_USERNAME}
-      SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD}
-      SPRING_REDIS_HOST: redis
-      SPRING_REDIS_PORT: 6379
-    networks:
-      - twilight-net
+
+
+  #twilight-back:
+   # build:
+    #  context: .
+    #container_name: twilight-back
+    #ports:
+     # - "80:8080"
+    #restart: always
+    #depends_on:
+     # redis:
+      #  condition: service_healthy
+      #mysql:
+       # condition: service_healthy
+    #environment:
+      #SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL}
+      #SPRING_DATASOURCE_USERNAME: ${MYSQL_USERNAME}
+      #SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD}
+      #SPRING_REDIS_HOST: redis
+      #SPRING_REDIS_PORT: 6379
+    #networks:
+      #- twilight-net
 
   redis:
-    image: redis:7
+    image: redis:8.0
     container_name: redis
     ports:
       - "6379:6379"
@@ -43,7 +45,7 @@ services:
       MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD}
       MYSQL_DATABASE: twilight
     ports:
-      - "3306:3306"
+      - "3307:3306"
     restart: always
     volumes:
       - mysql_data:/var/lib/mysql

--- a/src/main/java/com/twilight/twilight/domain/book/controller/BookController.java
+++ b/src/main/java/com/twilight/twilight/domain/book/controller/BookController.java
@@ -3,6 +3,7 @@ package com.twilight.twilight.domain.book.controller;
 import com.twilight.twilight.domain.book.dto.BookRecommendationRequestDto;
 import com.twilight.twilight.domain.book.dto.CompleteRecommendationDto;
 import com.twilight.twilight.domain.book.dto.QuestionAnswerResponseDto;
+import com.twilight.twilight.domain.book.dto.RecommendationRequestStatusResponseDto;
 import com.twilight.twilight.domain.book.dto.RecommendationViewDto;
 import com.twilight.twilight.domain.book.entity.recommendation.Recommendation;
 import com.twilight.twilight.domain.book.service.BookService;
@@ -63,6 +64,16 @@ public class BookController {
         log.info("AI 서버로부터 추천 결과 받음");
         bookService.completeRecommendation(completeRecommendationDto,token);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/recommendation/status")
+    @ResponseBody
+    public ResponseEntity<RecommendationRequestStatusResponseDto> getRecommendationStatus(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return bookService.getLatestRecommendationRequestStatus(userDetails.getMember().getMemberId())
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
     //pooling 방식으로 지속적인 요청

--- a/src/main/java/com/twilight/twilight/domain/book/dto/CompleteRecommendationDto.java
+++ b/src/main/java/com/twilight/twilight/domain/book/dto/CompleteRecommendationDto.java
@@ -1,11 +1,16 @@
 package com.twilight.twilight.domain.book.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.Lob;
 import lombok.Data;
 
 @Data
 public class CompleteRecommendationDto {
+
+    @JsonProperty("requestId")
+    @JsonAlias("request_id")
+    private Long requestId;
 
     @JsonProperty("member_id")
     private Long memberId;

--- a/src/main/java/com/twilight/twilight/domain/book/dto/RecommendationRequestStatusResponseDto.java
+++ b/src/main/java/com/twilight/twilight/domain/book/dto/RecommendationRequestStatusResponseDto.java
@@ -1,0 +1,18 @@
+package com.twilight.twilight.domain.book.dto;
+
+import com.twilight.twilight.domain.book.entity.recommendation.RecommendationRequestStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RecommendationRequestStatusResponseDto {
+    private Long requestId;
+    private RecommendationRequestStatus status;
+    private boolean completed;
+    private String message;
+}

--- a/src/main/java/com/twilight/twilight/domain/book/dto/RecommendationRequestStatusResponseDto.java
+++ b/src/main/java/com/twilight/twilight/domain/book/dto/RecommendationRequestStatusResponseDto.java
@@ -14,5 +14,6 @@ public class RecommendationRequestStatusResponseDto {
     private Long requestId;
     private RecommendationRequestStatus status;
     private boolean completed;
+    private int retryCount;
     private String message;
 }

--- a/src/main/java/com/twilight/twilight/domain/book/entity/recommendation/RecommendationRequest.java
+++ b/src/main/java/com/twilight/twilight/domain/book/entity/recommendation/RecommendationRequest.java
@@ -1,0 +1,68 @@
+package com.twilight.twilight.domain.book.entity.recommendation;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "recommendation_request")
+@Data
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class RecommendationRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    private RecommendationRequestStatus status;
+
+    @Builder.Default
+    @Column(name = "retry_count", nullable = false)
+    private int retryCount = 0;
+
+    @Lob
+    @Column(name = "error_message", columnDefinition = "LONGTEXT")
+    private String errorMessage;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    public void markSuccess() {
+        this.status = RecommendationRequestStatus.SUCCESS;
+        this.completedAt = LocalDateTime.now();
+        this.errorMessage = null;
+    }
+
+    public void markFailed(String errorMessage) {
+        this.status = RecommendationRequestStatus.FAILED;
+        this.errorMessage = errorMessage;
+    }
+
+    public boolean isSuccess() {
+        return RecommendationRequestStatus.SUCCESS.equals(this.status);
+    }
+}

--- a/src/main/java/com/twilight/twilight/domain/book/entity/recommendation/RecommendationRequest.java
+++ b/src/main/java/com/twilight/twilight/domain/book/entity/recommendation/RecommendationRequest.java
@@ -51,6 +51,11 @@ public class RecommendationRequest {
     @Column(name = "completed_at")
     private LocalDateTime completedAt;
 
+    public void markProcessing() {
+        this.status = RecommendationRequestStatus.PROCESSING;
+        this.errorMessage = null;
+    }
+
     public void markSuccess() {
         this.status = RecommendationRequestStatus.SUCCESS;
         this.completedAt = LocalDateTime.now();
@@ -62,7 +67,20 @@ public class RecommendationRequest {
         this.errorMessage = errorMessage;
     }
 
+    public void markDlq(String errorMessage) {
+        this.status = RecommendationRequestStatus.DLQ;
+        this.errorMessage = errorMessage;
+    }
+
+    public void increaseRetryCount() {
+        this.retryCount++;
+    }
+
     public boolean isSuccess() {
         return RecommendationRequestStatus.SUCCESS.equals(this.status);
+    }
+
+    public boolean isDlq() {
+        return RecommendationRequestStatus.DLQ.equals(this.status);
     }
 }

--- a/src/main/java/com/twilight/twilight/domain/book/entity/recommendation/RecommendationRequestStatus.java
+++ b/src/main/java/com/twilight/twilight/domain/book/entity/recommendation/RecommendationRequestStatus.java
@@ -1,0 +1,9 @@
+package com.twilight.twilight.domain.book.entity.recommendation;
+
+public enum RecommendationRequestStatus {
+    PENDING,
+    PROCESSING,
+    SUCCESS,
+    FAILED,
+    DLQ
+}

--- a/src/main/java/com/twilight/twilight/domain/book/repository/recommendation/RecommendationRequestRepository.java
+++ b/src/main/java/com/twilight/twilight/domain/book/repository/recommendation/RecommendationRequestRepository.java
@@ -1,0 +1,25 @@
+package com.twilight.twilight.domain.book.repository.recommendation;
+
+import com.twilight.twilight.domain.book.entity.recommendation.RecommendationRequest;
+import com.twilight.twilight.domain.book.entity.recommendation.RecommendationRequestStatus;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface RecommendationRequestRepository extends JpaRepository<RecommendationRequest, Long> {
+
+    Optional<RecommendationRequest> findTopByMemberIdOrderByCreatedAtDesc(Long memberId);
+
+    Optional<RecommendationRequest> findTopByMemberIdAndStatusOrderByCreatedAtDesc(
+            Long memberId,
+            RecommendationRequestStatus status
+    );
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select r from RecommendationRequest r where r.id = :id")
+    Optional<RecommendationRequest> findByIdForUpdate(@Param("id") Long id);
+}

--- a/src/main/java/com/twilight/twilight/domain/book/service/BookService.java
+++ b/src/main/java/com/twilight/twilight/domain/book/service/BookService.java
@@ -5,6 +5,8 @@ import com.twilight.twilight.domain.book.entity.book.Book;
 import com.twilight.twilight.domain.book.entity.book.BookTags;
 import com.twilight.twilight.domain.book.entity.question.MemberQuestion;
 import com.twilight.twilight.domain.book.entity.recommendation.Recommendation;
+import com.twilight.twilight.domain.book.entity.recommendation.RecommendationRequest;
+import com.twilight.twilight.domain.book.entity.recommendation.RecommendationRequestStatus;
 import com.twilight.twilight.domain.book.entity.tag.Tag;
 import com.twilight.twilight.domain.book.infra.stats.TagStatsRepository;
 import com.twilight.twilight.domain.book.repository.book.BookQueryRepository;
@@ -12,6 +14,7 @@ import com.twilight.twilight.domain.book.repository.book.BookRepository;
 import com.twilight.twilight.domain.book.repository.question.AnswerTagMappingRepository;
 import com.twilight.twilight.domain.book.repository.question.MemberQuestionAnswerRepository;
 import com.twilight.twilight.domain.book.repository.question.MemberQuestionRepository;
+import com.twilight.twilight.domain.book.repository.recommendation.RecommendationRequestRepository;
 import com.twilight.twilight.domain.book.repository.recommendation.RecommendationRepository;
 import com.twilight.twilight.domain.book.repository.tag.BookTagsRepository;
 import com.twilight.twilight.domain.book.repository.tag.TagRepository;
@@ -61,6 +64,7 @@ public class BookService {
     private final TagRepository tagRepository;
     private final BookQueryRepository bookQueryRepository;
     private final TagStatsRepository tagStatsRepository;
+    private final RecommendationRequestRepository recommendationRequestRepository;
 
     public QuestionAnswerResponseDto createCategoryQuestionAndAnswer() {
         MemberQuestion categoryQuestion =
@@ -182,7 +186,6 @@ public class BookService {
         return tagList;
     }
 
-    @Transactional(readOnly = true)
     public void requestRecommendationVer2(
             BookRecommendationRequestDto request,
             CustomUserDetails userDetails
@@ -572,7 +575,14 @@ public class BookService {
 
         AiRecommendationPayload.MemberInfo memberInfo = mapMemberToPayload(member, request, tagList);
         List<AiRecommendationPayload.BooksInfo> booksInfoList = mapBookListToPayload(bookList);
+        RecommendationRequest recommendationRequest = recommendationRequestRepository.save(
+                RecommendationRequest.builder()
+                        .memberId(member.getMemberId())
+                        .status(RecommendationRequestStatus.PENDING)
+                        .build()
+        );
         AiRecommendationPayload aiRecommendationPayload = AiRecommendationPayload.builder()
+                .requestId(recommendationRequest.getId())
                 .memberInfo(memberInfo)
                 .bookInfo(booksInfoList)
                 .build();
@@ -583,7 +593,14 @@ public class BookService {
                         .collect(Collectors.toList())
         );
 
-        aiGateway.send(aiRecommendationPayload);
+        try {
+            aiGateway.send(aiRecommendationPayload);
+        } catch (Exception e) {
+            recommendationRequest.markFailed(e.getMessage());
+            recommendationRequestRepository.save(recommendationRequest);
+            log.error("Failed to publish recommendation request. requestId={}", recommendationRequest.getId(), e);
+            throw e;
+        }
     }
 
     private AiRecommendationPayload.MemberInfo mapMemberToPayload (
@@ -652,14 +669,43 @@ public class BookService {
                 .toList();
     }
 
+    @Transactional
     public void completeRecommendation(
             CompleteRecommendationDto completeRecommendationDto,
             String token) {
-        if (! token.equals(System.getenv("AI_SECRET_TOKEN"))) {
+        if (!Objects.equals(token, System.getenv("AI_SECRET_TOKEN"))) {
             log.info("식별되지 않은 ai 서버 접근");
             return;
         }
         //추천 결과 중복 방지하기 위해 지움
+        Long requestId = completeRecommendationDto.getRequestId();
+        if (requestId == null) {
+            log.warn("AI recommendation callback ignored because requestId is missing. memberId={}",
+                    completeRecommendationDto.getMemberId());
+            return;
+        }
+
+        Optional<RecommendationRequest> recommendationRequestOptional =
+                recommendationRequestRepository.findByIdForUpdate(requestId);
+
+        if (recommendationRequestOptional.isEmpty()) {
+            log.warn("AI recommendation callback ignored because request was not found. requestId={}", requestId);
+            return;
+        }
+
+        RecommendationRequest recommendationRequest = recommendationRequestOptional.get();
+        if (recommendationRequest.isSuccess()) {
+            log.info("Duplicate AI recommendation callback ignored. requestId={}", requestId);
+            return;
+        }
+
+        if (!Objects.equals(recommendationRequest.getMemberId(), completeRecommendationDto.getMemberId())) {
+            log.warn("AI recommendation callback memberId mismatch. requestId={}, requestMemberId={}, callbackMemberId={}",
+                    requestId,
+                    recommendationRequest.getMemberId(),
+                    completeRecommendationDto.getMemberId());
+        }
+
         recommendationRepository.deleteByMemberId(completeRecommendationDto.getMemberId());
 
         recommendationRepository.save(
@@ -669,6 +715,18 @@ public class BookService {
                         .aiAnswer(completeRecommendationDto.getAiAnswer())
                         .build()
         );
+        recommendationRequest.markSuccess();
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<RecommendationRequestStatusResponseDto> getLatestRecommendationRequestStatus(Long memberId) {
+        return recommendationRequestRepository.findTopByMemberIdOrderByCreatedAtDesc(memberId)
+                .map(recommendationRequest -> RecommendationRequestStatusResponseDto.builder()
+                        .requestId(recommendationRequest.getId())
+                        .status(recommendationRequest.getStatus())
+                        .completed(RecommendationRequestStatus.SUCCESS.equals(recommendationRequest.getStatus()))
+                        .message(recommendationRequest.getErrorMessage())
+                        .build());
     }
 
     public Optional<Recommendation> findRecommendationOnly(Long memberId) {

--- a/src/main/java/com/twilight/twilight/domain/book/service/BookService.java
+++ b/src/main/java/com/twilight/twilight/domain/book/service/BookService.java
@@ -26,6 +26,7 @@ import com.twilight.twilight.domain.member.member.repository.PersonalityReposito
 import com.twilight.twilight.global.authentication.springSecurity.domain.CustomUserDetails;
 import com.twilight.twilight.global.cache.MemberQuestionCache;
 import com.twilight.twilight.global.gateway.ai.AiGateway;
+import com.twilight.twilight.global.gateway.ai.dto.AiRecommendationDlqPayload;
 import com.twilight.twilight.global.gateway.ai.dto.AiRecommendationPayload;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +34,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
@@ -48,6 +50,7 @@ public class BookService {
     private static final int MAX = 15;
     private static final int RANDOM_PICK = 10;
     private static final int TAG_ANSWER_COUNT = 5;
+    private static final int MAX_RETRY_COUNT = 3;
 
     private final MemberQuestionRepository memberQuestionRepository;
     private final MemberQuestionAnswerRepository memberQuestionAnswerRepository;
@@ -594,10 +597,11 @@ public class BookService {
         );
 
         try {
+            recommendationRequest.markProcessing();
+            recommendationRequestRepository.save(recommendationRequest);
             aiGateway.send(aiRecommendationPayload);
         } catch (Exception e) {
-            recommendationRequest.markFailed(e.getMessage());
-            recommendationRequestRepository.save(recommendationRequest);
+            handleRetryableFailure(recommendationRequest, e, aiRecommendationPayload);
             log.error("Failed to publish recommendation request. requestId={}", recommendationRequest.getId(), e);
             throw e;
         }
@@ -673,15 +677,17 @@ public class BookService {
     public void completeRecommendation(
             CompleteRecommendationDto completeRecommendationDto,
             String token) {
+        Long requestId = completeRecommendationDto == null ? null : completeRecommendationDto.getRequestId();
+
         if (!Objects.equals(token, System.getenv("AI_SECRET_TOKEN"))) {
-            log.info("식별되지 않은 ai 서버 접근");
+            log.info("Invalid AI server token. requestId={}", requestId);
+            markNonRetryableFailureIfRequestExists(requestId, "Invalid AI server token");
             return;
         }
         //추천 결과 중복 방지하기 위해 지움
-        Long requestId = completeRecommendationDto.getRequestId();
         if (requestId == null) {
             log.warn("AI recommendation callback ignored because requestId is missing. memberId={}",
-                    completeRecommendationDto.getMemberId());
+                    completeRecommendationDto == null ? null : completeRecommendationDto.getMemberId());
             return;
         }
 
@@ -699,11 +705,41 @@ public class BookService {
             return;
         }
 
+        if (recommendationRequest.isDlq()) {
+            log.warn("AI recommendation callback ignored because request is DLQ. requestId={}", requestId);
+            return;
+        }
+
+        if (!RecommendationRequestStatus.PROCESSING.equals(recommendationRequest.getStatus())) {
+            log.warn("AI recommendation callback ignored because request is not processing. requestId={}, status={}",
+                    requestId,
+                    recommendationRequest.getStatus());
+            return;
+        }
+
+        if (completeRecommendationDto.getMemberId() == null
+                || completeRecommendationDto.getBookId() == null
+                || completeRecommendationDto.getAiAnswer() == null) {
+            handleNonRetryableFailure(recommendationRequest, "Invalid AI recommendation callback payload");
+            log.warn("AI recommendation callback ignored because required payload is missing. requestId={}", requestId);
+            return;
+        }
+
         if (!Objects.equals(recommendationRequest.getMemberId(), completeRecommendationDto.getMemberId())) {
+            handleNonRetryableFailure(recommendationRequest, "AI recommendation callback memberId mismatch");
             log.warn("AI recommendation callback memberId mismatch. requestId={}, requestMemberId={}, callbackMemberId={}",
                     requestId,
                     recommendationRequest.getMemberId(),
                     completeRecommendationDto.getMemberId());
+            return;
+        }
+
+        if (!memberRepository.existsById(completeRecommendationDto.getMemberId())) {
+            handleNonRetryableFailure(recommendationRequest, "Member not found");
+            log.warn("AI recommendation callback ignored because member was not found. requestId={}, memberId={}",
+                    requestId,
+                    completeRecommendationDto.getMemberId());
+            return;
         }
 
         recommendationRepository.deleteByMemberId(completeRecommendationDto.getMemberId());
@@ -718,6 +754,76 @@ public class BookService {
         recommendationRequest.markSuccess();
     }
 
+    private void handleRetryableFailure(
+            RecommendationRequest request,
+            Exception e,
+            AiRecommendationPayload payload
+    ) {
+        request.increaseRetryCount();
+        String errorMessage = buildErrorMessage(e);
+
+        if (request.getRetryCount() >= MAX_RETRY_COUNT) {
+            request.markDlq(errorMessage);
+            recommendationRequestRepository.save(request);
+            publishDlq(request, errorMessage, payload);
+        } else {
+            request.markFailed(errorMessage);
+            recommendationRequestRepository.save(request);
+        }
+    }
+
+    private void publishDlq(
+            RecommendationRequest request,
+            String reason,
+            AiRecommendationPayload payload
+    ) {
+        try {
+            aiGateway.sendToDlq(
+                    AiRecommendationDlqPayload.builder()
+                            .requestId(request.getId())
+                            .memberId(request.getMemberId())
+                            .reason(reason)
+                            .retryCount(request.getRetryCount())
+                            .failedAt(LocalDateTime.now())
+                            .payload(payload)
+                            .build()
+            );
+        } catch (Exception dlqPublishException) {
+            log.error("Failed to publish recommendation request to DLQ stream. requestId={}",
+                    request.getId(),
+                    dlqPublishException);
+        }
+    }
+
+    private void handleNonRetryableFailure(RecommendationRequest request, String message) {
+        request.markFailed(message);
+        recommendationRequestRepository.save(request);
+    }
+
+    private void markNonRetryableFailureIfRequestExists(Long requestId, String message) {
+        if (requestId == null) {
+            return;
+        }
+
+        recommendationRequestRepository.findByIdForUpdate(requestId)
+                .filter(request -> !request.isSuccess())
+                .filter(request -> !request.isDlq())
+                .ifPresent(request -> handleNonRetryableFailure(request, message));
+    }
+
+    private String buildErrorMessage(Exception e) {
+        if (e == null) {
+            return "Unknown retryable failure";
+        }
+
+        String message = e.getMessage();
+        if (message == null || message.isBlank()) {
+            return e.getClass().getSimpleName();
+        }
+
+        return message;
+    }
+
     @Transactional(readOnly = true)
     public Optional<RecommendationRequestStatusResponseDto> getLatestRecommendationRequestStatus(Long memberId) {
         return recommendationRequestRepository.findTopByMemberIdOrderByCreatedAtDesc(memberId)
@@ -725,6 +831,7 @@ public class BookService {
                         .requestId(recommendationRequest.getId())
                         .status(recommendationRequest.getStatus())
                         .completed(RecommendationRequestStatus.SUCCESS.equals(recommendationRequest.getStatus()))
+                        .retryCount(recommendationRequest.getRetryCount())
                         .message(recommendationRequest.getErrorMessage())
                         .build());
     }

--- a/src/main/java/com/twilight/twilight/global/gateway/ai/AiGateway.java
+++ b/src/main/java/com/twilight/twilight/global/gateway/ai/AiGateway.java
@@ -1,11 +1,16 @@
 package com.twilight.twilight.global.gateway.ai;
 
 import com.twilight.twilight.global.gateway.ai.dto.AiRecommendationPayload;
+import com.twilight.twilight.global.gateway.ai.dto.AiRecommendationDlqPayload;
 
 public interface AiGateway {
 
     void send(
         AiRecommendationPayload aiRecommendationPayload
+    );
+
+    void sendToDlq(
+        AiRecommendationDlqPayload aiRecommendationDlqPayload
     );
 
 }

--- a/src/main/java/com/twilight/twilight/global/gateway/ai/RedisAiGateway.java
+++ b/src/main/java/com/twilight/twilight/global/gateway/ai/RedisAiGateway.java
@@ -2,6 +2,7 @@ package com.twilight.twilight.global.gateway.ai;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.twilight.twilight.global.gateway.ai.dto.AiRecommendationDlqPayload;
 import com.twilight.twilight.global.gateway.ai.dto.AiRecommendationPayload;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +22,7 @@ import java.util.Map;
 public class RedisAiGateway implements AiGateway {
 
     private static final String STREAM_KEY = "ai:recommend";
+    private static final String DLQ_STREAM_KEY = "ai:recommend:dlq";
     private static final String GROUP_NAME = "ai-consumers";
     private static final String PRODUCER_ID = "spring-backend";
 
@@ -98,6 +100,33 @@ public class RedisAiGateway implements AiGateway {
             redisTemplate.opsForStream().add(STREAM_KEY, body);
         } catch (Exception e) {
             log.error("Redis Stream publish failed. streamKey={}, requestId={}", STREAM_KEY, requestId, e);
+            throw e;
+        }
+    }
+
+    @Override
+    public void sendToDlq(AiRecommendationDlqPayload payload) {
+        Long requestId = payload == null ? null : payload.getRequestId();
+        try {
+            String json = new ObjectMapper().writeValueAsString(payload);
+            log.info("DLQ Payload JSON = {}", json);
+        } catch (JsonProcessingException e) {
+            log.error("DLQ payload serialization failed. requestId={}", requestId, e);
+        }
+
+        Map<String, Object> body = Map.of(
+                "requestId", payload.getRequestId(),
+                "memberId", payload.getMemberId(),
+                "reason", payload.getReason(),
+                "retryCount", payload.getRetryCount(),
+                "failedAt", payload.getFailedAt().toString(),
+                "payload", payload.getPayload()
+        );
+
+        try {
+            redisTemplate.opsForStream().add(DLQ_STREAM_KEY, body);
+        } catch (Exception e) {
+            log.error("Redis DLQ Stream publish failed. streamKey={}, requestId={}", DLQ_STREAM_KEY, requestId, e);
             throw e;
         }
     }

--- a/src/main/java/com/twilight/twilight/global/gateway/ai/RedisAiGateway.java
+++ b/src/main/java/com/twilight/twilight/global/gateway/ai/RedisAiGateway.java
@@ -3,13 +3,10 @@ package com.twilight.twilight.global.gateway.ai;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twilight.twilight.global.gateway.ai.dto.AiRecommendationPayload;
-import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
-import org.springframework.data.redis.RedisSystemException;
-import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.ReadOffset;
 import org.springframework.data.redis.connection.stream.StreamRecords;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -23,37 +20,30 @@ import java.util.Map;
 @Slf4j
 public class RedisAiGateway implements AiGateway {
 
-    private static final String STREAM_KEY   = "ai:recommend";// 스트림 이름
-    private static final String GROUP_NAME   = "ai-consumers";   // 컨슈머 그룹
-    private static final String PRODUCER_ID  = "spring-backend"; // 메시지 field
-
+    private static final String STREAM_KEY = "ai:recommend";
+    private static final String GROUP_NAME = "ai-consumers";
+    private static final String PRODUCER_ID = "spring-backend";
 
     private final RedisTemplate<String, Object> redisTemplate;
-
-
 
     @EventListener(ApplicationReadyEvent.class)
     public void init() {
         try {
-            ensureStreamAndGroup(STREAM_KEY, GROUP_NAME, true); // true = ReadOffset.latest()
+            ensureStreamAndGroup(STREAM_KEY, GROUP_NAME, true);
         } catch (Exception e) {
-            log.error("Redis 초기화 중 치명적 오류", e);
+            log.error("Redis stream initialization failed", e);
         }
     }
 
-
     private void ensureStreamAndGroup(String key, String group, boolean latest) {
-        // 1) 스트림 존재 보장: XADD 한 건 (MKSTREAM 대용)
         try {
             var init = StreamRecords.mapBacked(Collections.singletonMap("_init", "1"))
                     .withStreamKey(key);
             redisTemplate.opsForStream().add(init);
         } catch (Exception e) {
-            // XADD가 실패할 이유가 거의 없지만, 그래도 앱 죽이지 말고 로그만
-            log.warn("스트림 초기 XADD 실패(무시 가능): {}", e.toString());
+            log.warn("Redis stream initial XADD failed. key={}, error={}", key, e.toString());
         }
 
-        // 2) 그룹이 이미 있으면 생성 스킵
         try {
             var groups = redisTemplate.opsForStream().groups(key);
             if (groups != null && groups.stream().anyMatch(g -> group.equals(g.groupName()))) {
@@ -61,28 +51,23 @@ public class RedisAiGateway implements AiGateway {
                 return;
             }
         } catch (Exception e) {
-            // groups 호출이 지원 안 되거나 실패해도 아래 createGroup에서 BUSYGROUP 처리하므로 계속 진행
-            log.debug("groups 조회 실패(무시): {}", e.toString());
+            log.debug("Redis stream group lookup failed. key={}, group={}, error={}", key, group, e.toString());
         }
 
-        // 3) 그룹 생성 시도 (없을 때만 올 가능성 ↑)
         try {
             var offset = latest ? ReadOffset.latest() : ReadOffset.from("0-0");
             redisTemplate.opsForStream().createGroup(key, offset, group);
             log.info("Stream group created. key={}, group={}", key, group);
         } catch (Exception e) {
             if (isBusyGroup(e)) {
-                // 동시 초기화/레이스 등으로 이미 만들어졌다면 성공 취급
                 log.info("Group already exists (race). key={}, group={}", key, group);
                 return;
             }
-            // 다른 에러는 다시 던지되, init()에서 잡아 로그만 찍고 앱은 살리게 함
             throw e;
         }
     }
 
     private boolean isBusyGroup(Throwable e) {
-        // 메시지/원인체인에 BUSYGROUP가 있으면 true
         while (e != null) {
             String msg = String.valueOf(e.getMessage());
             if (msg.contains("BUSYGROUP") || msg.contains("Consumer Group name already exists")) {
@@ -93,15 +78,15 @@ public class RedisAiGateway implements AiGateway {
         return false;
     }
 
-
-
     @Override
     public void send(AiRecommendationPayload payload) {
+        Long requestId = payload == null ? null : payload.getRequestId();
         try {
             String json = new ObjectMapper().writeValueAsString(payload);
             log.info("Payload JSON = {}", json);
+            log.info("AI recommendation request payload requestId={}", requestId);
         } catch (JsonProcessingException e) {
-            log.error("❌ Payload 직렬화 실패", e);
+            log.error("Payload serialization failed. requestId={}", requestId, e);
         }
 
         Map<String, Object> body = Map.of(
@@ -109,9 +94,11 @@ public class RedisAiGateway implements AiGateway {
                 "payload", payload
         );
 
-        redisTemplate.opsForStream().add(STREAM_KEY, body);
+        try {
+            redisTemplate.opsForStream().add(STREAM_KEY, body);
+        } catch (Exception e) {
+            log.error("Redis Stream publish failed. streamKey={}, requestId={}", STREAM_KEY, requestId, e);
+            throw e;
+        }
     }
-
-
-
 }

--- a/src/main/java/com/twilight/twilight/global/gateway/ai/dto/AiRecommendationDlqPayload.java
+++ b/src/main/java/com/twilight/twilight/global/gateway/ai/dto/AiRecommendationDlqPayload.java
@@ -1,0 +1,21 @@
+package com.twilight.twilight.global.gateway.ai.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AiRecommendationDlqPayload {
+    private Long requestId;
+    private Long memberId;
+    private String reason;
+    private int retryCount;
+    private LocalDateTime failedAt;
+    private AiRecommendationPayload payload;
+}

--- a/src/main/java/com/twilight/twilight/global/gateway/ai/dto/AiRecommendationPayload.java
+++ b/src/main/java/com/twilight/twilight/global/gateway/ai/dto/AiRecommendationPayload.java
@@ -12,6 +12,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class AiRecommendationPayload {
+    private Long requestId;
     private MemberInfo memberInfo;
     private List<BooksInfo> bookInfo;
 

--- a/src/main/resources/db/migration/V23__add_recommendation_request.sql
+++ b/src/main/resources/db/migration/V23__add_recommendation_request.sql
@@ -1,0 +1,13 @@
+CREATE TABLE recommendation_request (
+    id bigint NOT NULL AUTO_INCREMENT,
+    member_id bigint NOT NULL,
+    status varchar(30) NOT NULL,
+    retry_count int NOT NULL DEFAULT 0,
+    error_message longtext DEFAULT NULL,
+    created_at datetime(6) NOT NULL,
+    updated_at datetime(6) DEFAULT NULL,
+    completed_at datetime(6) DEFAULT NULL,
+    PRIMARY KEY (id),
+    KEY idx_recommendation_request_member_created (member_id, created_at),
+    KEY idx_recommendation_request_member_status_created (member_id, status, created_at)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;


### PR DESCRIPTION
# PR: 추천 요청 상태 추적 및 DLQ 처리 구조 추가

## 주요 변경 사항

* RecommendationRequest 엔티티 추가
* requestId 기반 추천 요청 상태 추적 구현
* Redis Stream payload에 requestId 포함
* 추천 요청 상태값(PENDING / SUCCESS / FAILED / DLQ) 관리
* retryCount 및 errorMessage 기반 실패 처리 추가
* 재시도 한도 초과 요청을 `ai:recommend:dlq` Redis Stream으로 분리
* AI 완료 콜백 멱등성 처리 강화
* 추천 상태 조회 API 개선

## 기대 효과

* 추천 요청 흐름 추적 가능
* 유실 및 중복 처리 대응 강화
* 실패 요청 분리 및 운영 안정성 향상
* 향후 DLQ 재처리 기반 확보

기존 Redis Stream 구조와 추천 로직은 유지하면서 안정성과 복구 가능성을 보완했습니다.
